### PR TITLE
fix: 修复打包后 async 不可用的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,13 +15,13 @@
     "node": ">=10"
   },
   "dependencies": {
-    "@types/lodash-es": "^4.17.6",
-    "esbuild": "^0.17.4",
     "lodash-es": "^4.17.21"
   },
   "devDependencies": {
+    "@types/lodash-es": "^4.17.12",
     "cross-env": "^7.0.3",
-    "fs-extra": "^11.1.0",
+    "esbuild": "^0.21.4",
+    "fs-extra": "^11.2.0",
     "source-map-support": "^0.5.21"
   },
   "files": [

--- a/tools/build-config.js
+++ b/tools/build-config.js
@@ -25,6 +25,9 @@ module.exports = {
     treeShaking: true,
     logLevel: 'error',
     define: {'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV || 'development')},
+    supported: {
+      'async-await': true,
+    },
   },
   build: {
     // Bundles JavaScript.
@@ -50,5 +53,8 @@ module.exports = {
     treeShaking: true,
     logLevel: 'error',
     define: {'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV || 'development')},
+    supported: {
+      'async-await': true,
+    },
   }
 }


### PR DESCRIPTION
esbuild 会把 async 转换成用 yield 实现，但是转换后在 goja 上有点问题，故直接关闭对应转换。

Fix #5